### PR TITLE
Adds a `can_get_var` wrapper

### DIFF
--- a/dmsrc/_hooks.dm
+++ b/dmsrc/_hooks.dm
@@ -2,6 +2,16 @@
 	var/__auxtools_weakref_id //used by auxtools for weak references
 
 /**
+ * Sets a global proc to call to check to see if a variable can be read.
+ *
+ * The proc will be called with the arguments (datum/datum_to_read, var_name)
+ *
+ * required wrapper text the name of the proc to use as the wrapper
+ */
+/proc/__lua_set_can_get_var_wrapper(wrapper)
+	CRASH("auxlua not loaded")
+
+/**
  * Sets a global proc to call in place of just outright setting a datum's var to a given value
  *
  * The proc will be called with the arguments (datum/datum_to_modify, var_name, value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use auxtools::{hook, init, runtime, shutdown, DMResult, List, Proc, Runtime};
 use lua::{
-    AuxluaError, DMValue, GlobalWrapper, MluaValue, DATUM_CALL_PROC_WRAPPER,
+    AuxluaError, DMValue, GlobalWrapper, MluaValue, CAN_GET_VAR_WRAPPER, DATUM_CALL_PROC_WRAPPER,
     GLOBAL_CALL_PROC_WRAPPER, LUA_THREAD_START, PRINT_WRAPPER, SET_VAR_WRAPPER,
 };
 use mlua::{FromLua, Function, Lua, MultiValue, Table, Thread, ThreadStatus, ToLua, VmState};
@@ -358,6 +358,19 @@ fn over_exec_usage(_: &Lua, fraction_opt: Option<f32>) -> LuaResult<bool> {
     LUA_THREAD_START.with(|start| {
         EXECUTION_LIMIT
             .with(|limit| Ok(start.borrow().elapsed() > limit.borrow().mul_f32(fraction)))
+    })
+}
+
+/// Sets the proc path to call when getting
+/// a datum's variable check to see if said
+/// variable is even allowed to be read.
+#[hook("/proc/__lua_set_can_get_var_wrapper")]
+fn set_can_get_var_wrapper(wrapper: DMValue) {
+    wrapper.as_string().and_then(|wrapper_string| {
+        CAN_GET_VAR_WRAPPER.with(|wrapper| {
+            *wrapper.borrow_mut() = Some(wrapper_string);
+            Ok(DMValue::null())
+        })
     })
 }
 


### PR DESCRIPTION
This simply adds an `can_get_var` wrapper - in SS13, it would be this:

```dm
/proc/wrap_lua_can_get_var(datum/thingymajig, var_name)
	SHOULD_NOT_SLEEP(TRUE)
	return thingymajig.can_vv_get(var_name)
```

This allows for improved safety with certain things, such as preventing Lua scripts from being used to leak, like, the DB connection info or something

![2024-03-17 (1710732757) ~ dreamseeker](https://github.com/tgstation/auxlua/assets/65794972/b9f79f5f-fa29-4562-b997-fc4cfb4fae31)

